### PR TITLE
Makes Sidekiq compatible to Sidekiq 3.5.0 and Celluloid 0.17

### DIFF
--- a/examples/config.ru
+++ b/examples/config.ru
@@ -11,4 +11,6 @@ Sidekiq.configure_client do |config|
   config.redis = { :size => 1 }
 end
 
+use Rack::Session::Cookie, :secret => "some unique secret string here"
+
 run Sidekiq::Web

--- a/lib/sidetiq.rb
+++ b/lib/sidetiq.rb
@@ -7,7 +7,7 @@ require 'time'
 # gems
 require 'ice_cube'
 require 'sidekiq'
-require 'celluloid'
+require 'celluloid/current'
 
 # internal
 require 'sidetiq/config'

--- a/lib/sidetiq/supervisor.rb
+++ b/lib/sidetiq/supervisor.rb
@@ -1,6 +1,6 @@
 module Sidetiq
-  class Supervisor < Celluloid::SupervisionGroup
-    supervise Sidetiq::Actor::Clock, as: :sidetiq_clock
+  class Supervisor < Celluloid::Supervision::Container
+    supervise type: Sidetiq::Actor::Clock, as: :sidetiq_clock
 
     if Sidekiq.server?
       if handler_pool_size = Sidetiq.config.handler_pool_size
@@ -47,4 +47,3 @@ module Sidetiq
     end
   end
 end
-

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,4 @@
+ENV['RACK_ENV'] = 'test'
 if RUBY_PLATFORM != "java"
   require 'coveralls'
   Coveralls.wear!

--- a/test/test_sidetiq.rb
+++ b/test/test_sidetiq.rb
@@ -22,7 +22,7 @@ class TestSidetiq < Sidetiq::TestCase
     client = Sidekiq::Client.new
     SimpleWorker.perform_at(Time.local(2011, 1, 1, 1))
     hash = SimpleWorker.jobs.first
-    client.push_old(hash.merge("at" => hash["enqueued_at"]))
+    client.push_old(hash.merge("at" => hash["created_at"]))
 
     scheduled = Sidetiq.scheduled
 
@@ -39,7 +39,7 @@ class TestSidetiq < Sidetiq::TestCase
     client = Sidekiq::Client.new
     SimpleWorker.perform_at(Time.local(2011, 1, 1, 1))
     hash = SimpleWorker.jobs.first
-    client.push_old(hash.merge("at" => hash["enqueued_at"]))
+    client.push_old(hash.merge("at" => hash["created_at"]))
 
     assert_equal 1, Sidetiq.scheduled(SimpleWorker).length
     assert_equal 0, Sidetiq.scheduled(ScheduledWorker).length
@@ -52,11 +52,11 @@ class TestSidetiq < Sidetiq::TestCase
     client = Sidekiq::Client.new
     SimpleWorker.perform_at(Time.local(2011, 1, 1, 1))
     hash = SimpleWorker.jobs.first
-    client.push_old(hash.merge("at" => hash["enqueued_at"]))
+    client.push_old(hash.merge("at" => hash["created_at"]))
 
     ScheduledWorker.perform_at(Time.local(2011, 1, 1, 1))
     hash = ScheduledWorker.jobs.first
-    client.push_old(hash.merge("at" => hash["enqueued_at"]))
+    client.push_old(hash.merge("at" => hash["created_at"]))
 
     jobs = []
     Sidetiq.scheduled { |job| jobs << job }
@@ -126,4 +126,3 @@ class TestSidetiq < Sidetiq::TestCase
     end
   end
 end
-


### PR DESCRIPTION
Fixes "uninitialized constant Celluloid::SupervisionGroup" error on sidekiq start:

* require 'celluloid' instead of 'celluloid/current' in lib/sidetiq.rb
* Supervisor inherits from Celluloid::Supervision::Container instead
  of Celluloid::SupervisionGroup and uses new supervise method signature

More details about the changes in Celluloid can be found here:
https://github.com/celluloid/celluloid/wiki/DEPRECATION-WARNING

Fixes tests to work with Sidekiq 3.5.0:

* Use created_at instead of enqueued_at it the tests:
  > Set a created_at attribute when jobs are created, set enqueued_at only
    when they go into a queue. Fixes invalid latency calculations with
    scheduled jobs. [#2373, mrsimo]

  https://github.com/mperham/sidekiq/blob/master/Changes.md#340

* Set ENV['RACK_ENV'] = 'test' in test/helper.rb to fix tests to fix tests
  to work with Sidekiq 3.4.2 update:
  > Fix CSRF vulnerability in Web UI, thanks to Egor Homakov for reporting. [#2422]

  https://github.com/mperham/sidekiq/blob/master/Changes.md#342
  https://github.com/mperham/sidekiq/pull/2422/files

fixes #140